### PR TITLE
[SP] Scene Perception Refactor

### DIFF
--- a/realsense/scene_perception/win/scene_perception_object.h
+++ b/realsense/scene_perception/win/scene_perception_object.h
@@ -117,11 +117,8 @@ class ScenePerceptionObject : public xwalk::common::EventTarget {
       scoped_ptr<XWalkExtensionFunctionInfo> info);
   void DoCopySample(
       scoped_ptr<XWalkExtensionFunctionInfo> info);
-  void DoCopyVertices(
+  void DoGetVerticesOrNormals(bool isGettingVertices,
       scoped_ptr<XWalkExtensionFunctionInfo> info);
-  void DoCopyNormals(
-      scoped_ptr<XWalkExtensionFunctionInfo> info);
-  void DoCopyVerticesOrNormals(scoped_ptr<uint8[]> data);
 
   void DoCheckReconstructionFlag(
       scoped_ptr<XWalkExtensionFunctionInfo> info);
@@ -225,20 +222,9 @@ class ScenePerceptionObject : public xwalk::common::EventTarget {
 
   PXCImage* latest_color_image_;
   PXCImage* latest_depth_image_;
-  scoped_ptr<uint8[]> latest_vertices_;
-  scoped_ptr<uint8[]> latest_normals_;
 
   scoped_ptr<uint8[]> sample_message_;
   size_t sample_message_size_;
-
-  scoped_ptr<uint8[]> volume_preview_message_;
-  size_t volume_preview_message_size_;
-
-  scoped_ptr<uint8[]> vertices_normals_message_;
-  size_t vertices_normals_message_size_;
-
-  scoped_ptr<uint8[]> meshing_data_message_;
-  size_t meshing_data_message_size_;
 };
 
 }  // namespace scene_perception


### PR DESCRIPTION
This refactor mainly introduced command pattern to replace the
current sample process. Before this we kept the extra copy of sample
processing data(e.g. color/depth image, vertices/normals, message
buffer going to pass to JavaScript) and update them in every loop of
acquiring frame, which could have the memory waste and CPU consumption
issues. By introducing command pattern, it will process the
corresponding data on demand, and keeps the new API implementation
work much simpler.

This is the first step of SP refactor, will try to convert all the JS
API implementation using command if needed, and try to apply command
pattern to the situations that aquires frame asynchronously. This
structure can also be applied to other modules(e.g. Face), so the
Command and CommandQueue definitions are created within common
namespace.
