### PR TITLE
Fix dist folder empty issue.

### DIFF
--- a/realsense/common/dist.py
+++ b/realsense/common/dist.py
@@ -50,4 +50,4 @@ def main():
 
 
 if __name__ == '__main__':
-  sys.exit()
+  main()


### PR DESCRIPTION
The issue is caused by main() is not called in **main**, a silly mistake.

BUG=https://crosswalk-project.org/jira/browse/XWALK-6464
