### PR TITLE
[SP] Add comment in .idl to avoid build warning.

### DIFF
--- a/realsense/scene_perception/win/scene_perception.idl
+++ b/realsense/scene_perception/win/scene_perception.idl
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ScenePerception interface
 namespace scene_perception {
   dictionary CheckingEvent {
     double quality;


### PR DESCRIPTION
Build warning:
"
ninja: Entering directory `out\Release_x64'
[195/337] ACTION //extensions/realsense/scene_perception/win:scene_perception_idl_gen(//build/toolchain/win:64)
scene_perception must have a namespace-level comment. This will appear on the API summary page.
"
