### PR TITLE
[SP] Make the interfaces on SP object avaliable after initialized

### DIFF
--- a/realsense/scene_perception/win/scene_perception_object.cc
+++ b/realsense/scene_perception/win/scene_perception_object.cc
@@ -814,7 +814,7 @@ void ScenePerceptionObject::DoGetVerticesOrNormals(bool isGettingVertices,
     scoped_ptr<XWalkExtensionFunctionInfo> info) {
   DCHECK_EQ(sensemanager_thread_.message_loop(), base::MessageLoop::current());
 
-  if (state_ != STARTED) {
+  if (scene_perception_ == NULL) {
     VerticesOrNormals data;
     info->PostResult(GetVertices::Results::Create(
         data, std::string("Wrong state.")));
@@ -1147,7 +1147,7 @@ void ScenePerceptionObject::DoSetCameraPose(
 void ScenePerceptionObject::OnSetCameraPose(
     scoped_ptr<XWalkExtensionFunctionInfo> info) {
 
-  if (state_ != STARTED || !sensemanager_thread_.IsRunning()) {
+  if (scene_perception_ == NULL || !sensemanager_thread_.IsRunning()) {
     info->PostResult(CreateErrorResult(ERROR_CODE_EXEC_FAILED,
                                        "Wrong state to set camera pose."));
     return;  // Wrong state.
@@ -1190,7 +1190,7 @@ void ScenePerceptionObject::OnSetMeshingUpdateConfigs(
 
 void ScenePerceptionObject::OnConfigureSurfaceVoxelsData(
     scoped_ptr<XWalkExtensionFunctionInfo> info) {
-  if (!sensemanager_thread_.IsRunning() || state_ != STARTED) {
+  if (!sensemanager_thread_.IsRunning() || scene_perception_ == NULL) {
     info->PostResult(
         CreateErrorResult(ERROR_CODE_EXEC_FAILED,
                           "Wrong state to configure surface voxels data."));
@@ -1470,7 +1470,7 @@ void ScenePerceptionObject::DoQueryVolumePreview(
 void ScenePerceptionObject::OnQueryVolumePreview(
     scoped_ptr<XWalkExtensionFunctionInfo> info) {
   Image image;
-  if (!sensemanager_thread_.IsRunning() || state_ != STARTED) {
+  if (!sensemanager_thread_.IsRunning() || scene_perception_ == NULL) {
     info->PostResult(QueryVolumePreview::Results::Create(
         image, std::string("Wrong state to query volume preview.")));
     return;  // Wrong state.

--- a/realsense/scene_perception/win/scene_perception_object.h
+++ b/realsense/scene_perception/win/scene_perception_object.h
@@ -163,8 +163,6 @@ class ScenePerceptionObject : public xwalk::common::EventTarget {
     // Pipeline is initialized, SP module is paused.
     // Possible output in this state:
     //     checking event(depth quality)
-    //
-    //     getSample(raw color/depth image)
     INITIALIZED,
 
     // SP module starts to work, receiving raw smaples and reconstructing the
@@ -176,13 +174,18 @@ class ScenePerceptionObject : public xwalk::common::EventTarget {
     // Possible output in this state:
     //     sampleProcessed event(quality, tracking accuracy, camera pose)
     //     meshupdated event(no data)
-    //
-    //     getSample(processed sample including color/depth image)
+    STARTED
+
+    // Interfaces get/queryXXX are used to get processed data from SP module.
+    // They are availiable after the module being initialized.
+    // Although, they can be accessed in both "INITIALIZED" and "TARTED" states,
+    // they may return unavaliable data if the SP module haven't successfully
+    // established the co-ordinate system from the first frame.
+    //     getSample(color/depth image)
     //     getCameraPose
     //     getVertices
     //     getNormals
     //     getMeshData
-    STARTED
   };
 
   State state_;

--- a/spec/scene-perception.html
+++ b/spec/scene-perception.html
@@ -1265,10 +1265,8 @@
 
           // -- INITIALIZED
           // Pipeline is initialized, SP module is paused.
-          // Possible output in this state:
+          // Possible event in this state:
           //     checking event(depth quality)
-          //
-          //     getSample(raw color/depth image)
 
           // -- STARTED
           // SP module starts to work, receiving raw smaples and reconstructing the
@@ -1277,9 +1275,15 @@
           // is acceptable.
           // SP module is on tracking, and on reconstructing if reconstruction
           // flag enabled.
-          // Possible output in this state:
+          // Possible events in this state:
           //     sampleProcessed event(quality, tracking accuracy, camera pose)
           //     meshupdated event(no data)
+
+          // Interfaces get/queryXXX are used to get processed data from SP module.
+          // They are availiable after the module being initialized.
+          // Although, they can be accessed in both "INITIALIZED" and "TARTED" states,
+          // they may return unavaliable data if the SP module haven't successfully
+          // established the co-ordinate system from the first frame.
           //
           //     getSample(processed sample including color/depth image)
           //     getMeshData


### PR DESCRIPTION
We need to make the API avaliable even the SP was paused, so that we can get the volume preview when stoped in the PR: https://github.com/crosswalk-project/realsense-extensions-crosswalk/pull/36 
