### PR TITLE
[NPM] Remove the format-json dependency

### DIFF
--- a/realsense/common/npm_install_template.js
+++ b/realsense/common/npm_install_template.js
@@ -13,7 +13,6 @@ var uninstall = (process.argv[2] === '--uninstall');
 
 var FS = require('fs');
 var Path = require('path');
-var FormatJson = require('format-json');
 
 var buffer;
 try {
@@ -63,7 +62,7 @@ if (extensionIndex === -1 && uninstall === false) {
 
 if (updated) {
   try {
-    var buffer = FormatJson.plain(json);
+    var buffer = JSON.stringify(json, null, 2);
     FS.writeFileSync('../../manifest.json', buffer);
   } catch (e) {
     console.log('Failed to upate manifest.json.');

--- a/realsense/enhanced_photography/npm/package.json
+++ b/realsense/enhanced_photography/npm/package.json
@@ -17,9 +17,6 @@
     "postinstall": "node npm_install.js",
     "postuninstall": "node npm_install.js --uninstall"
   },
-  "dependencies": {
-    "format-json": "~1.0.3"
-  },
   "author": "",
   "license": "BSD-3-Clause",
   "bugs": {

--- a/realsense/face/npm/package.json
+++ b/realsense/face/npm/package.json
@@ -18,9 +18,6 @@
     "postinstall": "node npm_install.js",
     "postuninstall": "node npm_install.js --uninstall"
   },
-  "dependencies": {
-    "format-json": "~1.0.3"
-  },
   "author": "",
   "license": "BSD-3-Clause",
   "bugs": {

--- a/realsense/hand/npm/package.json
+++ b/realsense/hand/npm/package.json
@@ -16,9 +16,6 @@
     "postinstall": "node npm_install.js",
     "postuninstall": "node npm_install.js --uninstall"
   },
-  "dependencies": {
-    "format-json": "~1.0.3"
-  },
   "author": "",
   "license": "BSD-3-Clause",
   "bugs": {

--- a/realsense/scene_perception/npm/package.json
+++ b/realsense/scene_perception/npm/package.json
@@ -16,9 +16,6 @@
     "postinstall": "node npm_install.js",
     "postuninstall": "node npm_install.js --uninstall"
   },
-  "dependencies": {
-    "format-json": "~1.0.3"
-  },
   "author": "",
   "license": "BSD-3-Clause",
   "bugs": {


### PR DESCRIPTION
npm uninstalls dependency before executes postuninstall script.

Depending on format-json leads to postuinstall script error.

Use built-in JSON object instead.
