### PR TITLE
[Polymer] Activate next page once previous page clear done

### DIFF
--- a/sample/src_polymer/elements/scene-perception-pages/main.js
+++ b/sample/src_polymer/elements/scene-perception-pages/main.js
@@ -7,12 +7,18 @@ var myStatus = new Status();
 
 function destroySP(spDom) {
   var sp = getSP();
-  if (!sp || spDom.spState <= 0) return;
+  if (!sp || spDom.spState <= 0) {
+    spDom.fire('clear');
+    return;
+  }
 
   sp.destroy().then(function() {
     spDom.spState = 0;
     myStatus.info('destroy succeeds');
-  }, errorHandler);
+    spDom.fire('clear');
+  }, function(e) {
+    spDom.fire('clear');
+  });
 }
 
 function main(spDom) {

--- a/sample/src_polymer/index.html
+++ b/sample/src_polymer/index.html
@@ -83,14 +83,14 @@
           <iron-pages attr-for-selected="page-name" selected="[[selectedPage]]"
                       on-iron-deselect="_onPageDeactivated"
                       on-iron-select="_onPageActivated">
-            <photo-capture-page page-name="Photo Capture"></photo-capture-page>
+            <photo-capture-page page-name="Photo Capture" on-clear="_onPageCleared"></photo-capture-page>
             <photo-page page-name="Photo"></photo-page>
             <enhanced-photo-page page-name="Enhanced Photo"></enhanced-photo-page>
             <photo-utils-page page-name="Photo Utilities"></photo-utils-page>
             <segmentation-page page-name="Segmentation"></segmentation-page>
             <motion-effect-page page-name="Motion Effect"></motion-effect-page>
-            <scene-perception-page page-name="Scene Perception"></scene-perception-page>
-            <face-page page-name="Face"></face-page>
+            <scene-perception-page page-name="Scene Perception" on-clear="_onPageCleared"></scene-perception-page>
+            <face-page page-name="Face" on-clear="_onPageCleared"></face-page>
           </iron-pages>
 
         </paper-header-panel>

--- a/sample/src_polymer/scripts/app.js
+++ b/sample/src_polymer/scripts/app.js
@@ -2,6 +2,8 @@
   'use strict';
 
   var app = document.querySelector('#app');
+  var clearingPage = null;
+  var nextPage = null;
 
   app.selectedPage = 'Face';
 
@@ -11,11 +13,44 @@
   };
 
   app._onPageDeactivated = function(e) {
-    e.detail.item.activated = false;
+    var page = e.detail.item;
+    console.log('_onPageDeactivated : ' + page.getAttribute('page-name'));
+    // Only handle pages(Face,SP,PhotoCapture) having 'activated' property.
+    if (page.activated != undefined) {
+      clearingPage = page;
+      page.activated = false;
+    }
   };
 
   app._onPageActivated = function(e) {
-    e.detail.item.activated = true;
+    var page = e.detail.item;
+    console.log('_onPageActivated : ' + page.getAttribute('page-name'));
+    // Only handle pages(Face,SP,PhotoCapture) having 'activated' property.
+    if (page.activated != undefined) {
+      if (clearingPage) {
+        // Previous page is clearing, just record nextPage.
+        console.log('_onPageActivated : page is clearing: ' +
+                    clearingPage.getAttribute('page-name'));
+        nextPage = page;
+      } else {
+        page.activated = true;
+      }
+    }
+  };
+
+  app._onPageCleared = function(e) {
+    console.log('_onPageCleared : ' + e.target.getAttribute('page-name'));
+    if (e.target == clearingPage) {
+      console.log('_onPageCleared : clearingPage got reset: ' +
+                  clearingPage.getAttribute('page-name'));
+      // The previous page clear done.
+      clearingPage = null;
+      if (nextPage) {
+        console.log('_onPageCleared : start nextPage: ' + nextPage.getAttribute('page-name'));
+        nextPage.activated = true;
+        nextPage = null;
+      }
+    }
   };
 
   app.addEventListener('dom-change', function() {


### PR DESCRIPTION
When Face, SP, PhotoCapture pages got deactivated,
they need to release camera access, but the release process is
async, this PR lets them fire a 'clear' event after release done,
afterwards the next page will get activated.

BUG=XWALK-6867
