### PR TITLE
[Test] Use application/json media type for JSON-encoded requests

### DIFF
--- a/test/resources/testharnessreport.js
+++ b/test/resources/testharnessreport.js
@@ -412,7 +412,7 @@ function dump_test_results(tests, status) {
         }
     };
     request.open("POST", "test.py");
-    request.setRequestHeader("Content-Type", "text/plain;charset=UTF-8");
+    request.setRequestHeader("Content-Type", "application/json");
     request.send(JSON.stringify(data));
 }
 


### PR DESCRIPTION
It is recommended by JavaScript: The Definitive Guide
and standardized by

https://tools.ietf.org/html/rfc4627
